### PR TITLE
Fix serious bug in re-sort algorithm.

### DIFF
--- a/server/bert_serving/server/__init__.py
+++ b/server/bert_serving/server/__init__.py
@@ -222,7 +222,7 @@ class BertSink(Process):
                             'send back\tsize: %d\tjob id:%s\t' % (
                                 job_checksum[job_info], job_info))
                         # re-sort to the original order
-                        tmp = [x[0] for x in sorted(tmp, key=lambda x: x[1])]
+                        tmp = [x[0] for x in sorted(tmp, key=lambda x: int(x[1]))]
                         client_addr, req_id = job_info.split(b'#')
                         send_ndarray(sender, client_addr, np.concatenate(tmp, axis=0), req_id)
                         pending_result.pop(job_info)


### PR DESCRIPTION
It treats a byte as a string by default. So, if you sort `1, 5, 10`, it will return the wrong result as `1, 10, 5` instead of `1, 5, 10`. Therefore, It's necessary to explicitly convert byte to int.