### PR TITLE
Tmp file (generated by ipc socket) location choice 

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,11 @@ bc2 = BertClient()
 bc2.encode(lst_str)
 ```
 
+##### **Q:** After running the server, I have several garbage `tmpXXXX` folders. How can I change this behavior ?
+
+**A:** These folders are used by ZeroMQ to store sockets. You can choose a different location by setting the environment variable `ZEROMQ_SOCK_TMP_DIR` :
+`export ZEROMQ_SOCK_TMP_DIR=/tmp/`
+
 ##### **Q:** The cosine similarity of two sentence vectors is unreasonably high (e.g. always > 0.8), what's wrong?
 
 **A:** A decent representation for a downstream task doesn't mean that it will be meaningful in terms of cosine distance. Since cosine distance is a linear space where all dimensions are weighted equally. if you want to use cosine distance anyway, then please focus on the rank not the absolute value. Namely, do not use:

--- a/server/bert_serving/server/__init__.py
+++ b/server/bert_serving/server/__init__.py
@@ -41,7 +41,7 @@ def _auto_bind(socket):
             tmp_dir = os.path.join(tmp_dir, str(uuid.uuid1())[:8])
         except KeyError:
             tmp_dir = '*'
-        print("DEBUG  = {}".format(tmp_dir))
+        
         socket.bind('ipc://{}'.format(tmp_dir))
     return socket.getsockopt(zmq.LAST_ENDPOINT).decode('ascii')
 

--- a/server/bert_serving/server/__init__.py
+++ b/server/bert_serving/server/__init__.py
@@ -13,6 +13,7 @@ from multiprocessing import Process
 import numpy as np
 import tensorflow as tf
 import zmq
+import uuid
 from tensorflow.python.estimator.estimator import Estimator
 from tensorflow.python.estimator.run_config import RunConfig
 from termcolor import colored
@@ -32,7 +33,16 @@ def _auto_bind(socket):
     if os.name == 'nt':  # for Windows
         socket.bind_to_random_port('tcp://*')
     else:
-        socket.bind('ipc://*')
+        # Get the location for tmp file for sockets
+        try:
+            tmp_dir = os.environ['ZEROMQ_SOCK_TMP_DIR']
+            if not os.path.exists(tmp_dir):
+                raise ValueError("This directory for sockets ({}) does not seems to exist.".format(tmp_dir))
+            tmp_dir = os.path.join(tmp_dir, str(uuid.uuid1())[:8])
+        except KeyError:
+            tmp_dir = '*'
+        print("DEBUG  = {}".format(tmp_dir))
+        socket.bind('ipc://{}'.format(tmp_dir))
     return socket.getsockopt(zmq.LAST_ENDPOINT).decode('ascii')
 
 


### PR DESCRIPTION
**Code greatly inspired by #118** 

It's basically the same pull request, but you can choose the location of file using an environment variable. The default behavior (the environment variable is not set) is the same as previously : tmp file are created on the current folder.

**Solve #73** (I was indeed talking about socket tmp files generated ^^)

_Note : the choice of the location is done through environment variable. In my opinion, it's less invasive than command line argument._