### PR TITLE
add timeout to BertClient

### DIFF
--- a/client/bert_serving/client/__init__.py
+++ b/client/bert_serving/client/__init__.py
@@ -33,7 +33,7 @@ Response = namedtuple('Response', ['id', 'content'])
 class BertClient:
     def __init__(self, ip='localhost', port=5555, port_out=5556,
                  output_fmt='ndarray', show_server_config=False,
-                 identity=None, check_version=True):
+                 identity=None, check_version=True, timeout=2000):
         """ A client object connected to a BertServer
 
         Create a BertClient that connects with a BertServer
@@ -46,6 +46,8 @@ class BertClient:
         either in numpy array or python List[List[float]] (ndarray/list)
         :param show_server_config: whether to show server configs when first connected
         :param identity: the UUID of this client
+        :param check_version: check if server has the same version as client, raise AttributeError if not the same
+        :param timeout: set the timeout (milliseconds) for receive operation on the client
         """
         self.context = zmq.Context()
         self.sender = self.context.socket(zmq.PUSH)
@@ -54,6 +56,7 @@ class BertClient:
 
         self.receiver = self.context.socket(zmq.SUB)
         self.receiver.setsockopt(zmq.SUBSCRIBE, self.identity)
+        self.receiver.setsockopt(zmq.RCVTIMEO, timeout)
         self.receiver.connect('tcp://%s:%d' % (ip, port_out))
 
         self.request_id = 0

--- a/client/bert_serving/client/__init__.py
+++ b/client/bert_serving/client/__init__.py
@@ -12,6 +12,8 @@ import numpy as np
 import zmq
 from zmq.utils import jsonapi
 
+__all__ = ['__version__', 'BertClient']
+
 # in the future client version must match with server version
 __version__ = '1.5.6'
 
@@ -87,8 +89,8 @@ class BertClient:
         self.receiver.close()
         self.context.term()
 
-    def _send(self, msg):
-        self.sender.send_multipart([self.identity, msg, b'%d' % self.request_id])
+    def _send(self, msg, msg_len=0):
+        self.sender.send_multipart([self.identity, msg, b'%d' % self.request_id, b'%d' % msg_len])
         self.pending_request.add(self.request_id)
         self.request_id += 1
 
@@ -142,7 +144,7 @@ class BertClient:
             self._check_input_lst_str(texts)
 
         texts = _unicode(texts)
-        self._send(jsonapi.dumps(texts))
+        self._send(jsonapi.dumps(texts), len(texts))
         return self._recv_ndarray().content if blocking else None
 
     def fetch(self, delay=.0):

--- a/client/bert_serving/client/__init__.py
+++ b/client/bert_serving/client/__init__.py
@@ -133,7 +133,8 @@ class BertClient:
             self._send(b'SHOW_CONFIG')
             return jsonapi.loads(self._recv().content[1])
         except zmq.error.Again as _e:
-            t_e = TimeoutError('no response from the server after %dms, is the server on line?' % self.timeout)
+            t_e = TimeoutError(
+                'no response from the server after ("timeout"=%dms), is the server on line?' % self.timeout)
             if _py2:
                 raise t_e
             else:

--- a/client/bert_serving/client/__init__.py
+++ b/client/bert_serving/client/__init__.py
@@ -120,7 +120,8 @@ class BertClient:
             'port': self.port,
             'port_out': self.port_out,
             'server_ip': self.ip,
-            'client_version': __version__
+            'client_version': __version__,
+            'timeout': self.timeout
         }
 
     @property

--- a/client/bert_serving/client/__init__.py
+++ b/client/bert_serving/client/__init__.py
@@ -35,7 +35,7 @@ Response = namedtuple('Response', ['id', 'content'])
 class BertClient:
     def __init__(self, ip='localhost', port=5555, port_out=5556,
                  output_fmt='ndarray', show_server_config=False,
-                 identity=None, check_version=True, timeout=2000):
+                 identity=None, check_version=True, timeout=5000):
         """ A client object connected to a BertServer
 
         Create a BertClient that connects with a BertServer
@@ -134,7 +134,8 @@ class BertClient:
             return jsonapi.loads(self._recv().content[1])
         except zmq.error.Again as _e:
             t_e = TimeoutError(
-                'no response from the server after ("timeout"=%dms), is the server on line?' % self.timeout)
+                'no response from the server (with "timeout"=%d ms), '
+                'is the server on-line? is network broken? are "port" and "port_out" correct?' % self.timeout)
             if _py2:
                 raise t_e
             else:

--- a/server/bert_serving/server/__init__.py
+++ b/server/bert_serving/server/__init__.py
@@ -22,6 +22,7 @@ from .bert.tokenization import FullTokenizer
 from .graph import optimize_graph
 from .helper import *
 
+__all__ = ['__version__', 'BertServer']
 __version__ = '1.5.6'
 
 _tf_ver_ = check_tf_version()

--- a/server/bert_serving/server/__init__.py
+++ b/server/bert_serving/server/__init__.py
@@ -105,17 +105,17 @@ class BertServer(threading.Thread):
                 avail_gpu = GPUtil.getAvailable(order='memory', limit=min(num_all_gpu, self.num_worker))
                 num_avail_gpu = len(avail_gpu)
                 if 0 < num_avail_gpu < self.num_worker:
-                    self.logger.warn('only %d out of %d GPU(s) is available/free, but "-num_worker=%d"' %
-                                     (num_avail_gpu, num_all_gpu, self.num_worker))
-                    self.logger.warn('multiple workers will be allocated to one GPU, '
-                                     'may not scale well and may raise out-of-memory')
+                    self.logger.warning('only %d out of %d GPU(s) is available/free, but "-num_worker=%d"' %
+                                        (num_avail_gpu, num_all_gpu, self.num_worker))
+                    self.logger.warning('multiple workers will be allocated to one GPU, '
+                                        'may not scale well and may raise out-of-memory')
                     device_map = (avail_gpu * self.num_worker)[: self.num_worker]
                     run_on_gpu = True
                 elif num_avail_gpu == 0:
-                    self.logger.warn('no GPU resource available, fall back to CPU')
+                    self.logger.warning('no GPU resource available, fall back to CPU')
             except FileNotFoundError:
-                self.logger.warn('nvidia-smi is missing, often means no gpu on this machine. '
-                                 'fall back to cpu!')
+                self.logger.warning('nvidia-smi is missing, often means no gpu on this machine. '
+                                    'fall back to cpu!')
 
         self.logger.info('device map: \n\t\t%s' % '\n\t\t'.join(
             'worker %2d -> %s' % (w_id, ('gpu %2d' % g_id) if g_id >= 0 else 'cpu') for w_id, g_id in

--- a/server/bert_serving/server/__init__.py
+++ b/server/bert_serving/server/__init__.py
@@ -104,12 +104,12 @@ class BertServer(threading.Thread):
                 num_all_gpu = len(GPUtil.getGPUs())
                 avail_gpu = GPUtil.getAvailable(order='memory', limit=min(num_all_gpu, self.num_worker))
                 num_avail_gpu = len(avail_gpu)
-                print(num_avail_gpu)
-                if 0 < num_avail_gpu < self.num_worker:
-                    self.logger.warning('only %d out of %d GPU(s) is available/free, but "-num_worker=%d"' %
-                                        (num_avail_gpu, num_all_gpu, self.num_worker))
-                    self.logger.warning('multiple workers will be allocated to one GPU, '
-                                        'may not scale well and may raise out-of-memory')
+                if 0 < num_avail_gpu <= self.num_worker:
+                    if num_avail_gpu < self.num_worker:
+                        self.logger.warning('only %d out of %d GPU(s) is available/free, but "-num_worker=%d"' %
+                                            (num_avail_gpu, num_all_gpu, self.num_worker))
+                        self.logger.warning('multiple workers will be allocated to one GPU, '
+                                            'may not scale well and may raise out-of-memory')
                     device_map = (avail_gpu * self.num_worker)[: self.num_worker]
                     run_on_gpu = True
                 elif num_avail_gpu == 0:

--- a/server/bert_serving/server/__init__.py
+++ b/server/bert_serving/server/__init__.py
@@ -104,13 +104,15 @@ class BertServer(threading.Thread):
                 num_all_gpu = len(GPUtil.getGPUs())
                 avail_gpu = GPUtil.getAvailable(order='memory', limit=min(num_all_gpu, self.num_worker))
                 num_avail_gpu = len(avail_gpu)
-                if num_avail_gpu < self.num_worker:
+                if 0 < num_avail_gpu < self.num_worker:
                     self.logger.warn('only %d out of %d GPU(s) is available/free, but "-num_worker=%d"' %
                                      (num_avail_gpu, num_all_gpu, self.num_worker))
                     self.logger.warn('multiple workers will be allocated to one GPU, '
                                      'may not scale well and may raise out-of-memory')
-                device_map = (avail_gpu * self.num_worker)[: self.num_worker]
-                run_on_gpu = True
+                    device_map = (avail_gpu * self.num_worker)[: self.num_worker]
+                    run_on_gpu = True
+                elif num_avail_gpu == 0:
+                    self.logger.warn('no GPU resource available, fall back to CPU')
             except FileNotFoundError:
                 self.logger.warn('nvidia-smi is missing, often means no gpu on this machine. '
                                  'fall back to cpu!')

--- a/server/bert_serving/server/__init__.py
+++ b/server/bert_serving/server/__init__.py
@@ -37,7 +37,7 @@ class ServerCommand:
 class BertServer(threading.Thread):
     def __init__(self, args):
         super().__init__()
-        self.logger = set_logger(colored('VENTILATOR', 'magenta'))
+        self.logger = set_logger(colored('VENTILATOR', 'magenta'), args.verbose)
 
         self.model_dir = args.model_dir
         self.max_seq_len = args.max_seq_len
@@ -182,7 +182,7 @@ class BertSink(Process):
         super().__init__()
         self.port = args.port_out
         self.exit_flag = multiprocessing.Event()
-        self.logger = set_logger(colored('SINK', 'green'))
+        self.logger = set_logger(colored('SINK', 'green'), args.verbose)
         self.front_sink_addr = front_sink_addr
 
     def close(self):
@@ -265,7 +265,7 @@ class BertWorker(Process):
         super().__init__()
         self.worker_id = id
         self.device_id = device_id
-        self.logger = set_logger(colored('WORKER-%d' % self.worker_id, 'yellow'))
+        self.logger = set_logger(colored('WORKER-%d' % self.worker_id, 'yellow'), args.verbose)
         self.max_seq_len = args.max_seq_len
         self.daemon = True
         self.exit_flag = multiprocessing.Event()

--- a/server/bert_serving/server/__init__.py
+++ b/server/bert_serving/server/__init__.py
@@ -328,7 +328,6 @@ class BertWorker(Process):
     def _run(self, receiver, sink):
         self.logger.info('use device %s, load graph from %s' %
                          ('cpu' if self.device_id < 0 else ('gpu: %d' % self.device_id), self.graph_path))
-        self.logger.info('please ignore "WARNING: Using temporary folder as model directory"...')
 
         tf = import_tf(self.device_id, self.verbose)
         estimator = self.get_estimator(tf)

--- a/server/bert_serving/server/__init__.py
+++ b/server/bert_serving/server/__init__.py
@@ -272,6 +272,7 @@ class BertWorker(Process):
         self.prefetch_factor = 10
         self.gpu_memory_fraction = args.gpu_memory_fraction
         self.model_dir = args.model_dir
+        self.verbose = args.verbose
         self.graph_path = graph_path
 
     def close(self):
@@ -320,11 +321,9 @@ class BertWorker(Process):
     def _run(self, receiver, sink):
         self.logger.info('use device %s, load graph from %s' %
                          ('cpu' if self.device_id < 0 else ('gpu: %d' % self.device_id), self.graph_path))
-        os.environ['CUDA_VISIBLE_DEVICES'] = str(self.device_id)
-        os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
         self.logger.info('please ignore "WARNING: Using temporary folder as model directory"...')
 
-        import tensorflow as tf
+        tf = import_tf(self.device_id, self.verbose)
         estimator = self.get_estimator(tf)
 
         receiver.connect(self.worker_address)

--- a/server/bert_serving/server/__init__.py
+++ b/server/bert_serving/server/__init__.py
@@ -104,6 +104,7 @@ class BertServer(threading.Thread):
                 num_all_gpu = len(GPUtil.getGPUs())
                 avail_gpu = GPUtil.getAvailable(order='memory', limit=min(num_all_gpu, self.num_worker))
                 num_avail_gpu = len(avail_gpu)
+                print(num_avail_gpu)
                 if 0 < num_avail_gpu < self.num_worker:
                     self.logger.warning('only %d out of %d GPU(s) is available/free, but "-num_worker=%d"' %
                                         (num_avail_gpu, num_all_gpu, self.num_worker))

--- a/server/bert_serving/server/graph.py
+++ b/server/bert_serving/server/graph.py
@@ -7,6 +7,8 @@ from enum import Enum
 from .bert import modeling
 from .helper import import_tf
 
+__all__ = ['PoolingStrategy', 'optimize_graph']
+
 
 class PoolingStrategy(Enum):
     NONE = 0

--- a/server/bert_serving/server/graph.py
+++ b/server/bert_serving/server/graph.py
@@ -5,6 +5,7 @@ import tempfile
 from enum import Enum
 
 from .bert import modeling
+from .helper import import_tf
 
 
 class PoolingStrategy(Enum):
@@ -30,11 +31,7 @@ class PoolingStrategy(Enum):
 
 def optimize_graph(args):
     # we don't need GPU for optimizing the graph
-    os.environ['CUDA_VISIBLE_DEVICES'] = '-1'
-    os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
-
-    import tensorflow as tf
-    tf.logging.set_verbosity(tf.logging.ERROR)
+    tf = import_tf(verbose=args.verbose)
     from tensorflow.python.tools.optimize_for_inference_lib import optimize_for_inference
 
     config = tf.ConfigProto(device_count={'GPU': 0}, allow_soft_placement=True)

--- a/server/bert_serving/server/helper.py
+++ b/server/bert_serving/server/helper.py
@@ -4,9 +4,9 @@ import os
 import uuid
 
 import zmq
+from bert_serving.server import __version__
 from zmq.utils import jsonapi
 
-from . import __version__
 from .graph import PoolingStrategy
 
 __all__ = ['set_logger', 'send_ndarray', 'get_args_parser', 'check_tf_version', 'auto_bind']

--- a/server/bert_serving/server/helper.py
+++ b/server/bert_serving/server/helper.py
@@ -45,17 +45,17 @@ def get_args_parser():
     parser.add_argument('-port', '-port_in', '-port_data', type=int, default=5555,
                         help='server port for receiving data from client')
     parser.add_argument('-port_out', '-port_result', type=int, default=5556,
-                        help='server port for outputting result to client')
+                        help='server port for sending result to client')
     parser.add_argument('-pooling_layer', type=int, nargs='+', default=[-2],
                         help='the encoder layer(s) that receives pooling. '
-                             'Give a list in order to concatenate several layers into 1.')
+                             'Give a list in order to concatenate several layers into one')
     parser.add_argument('-pooling_strategy', type=PoolingStrategy.from_string,
                         default=PoolingStrategy.REDUCE_MEAN, choices=list(PoolingStrategy),
                         help='the pooling strategy for generating encoding vectors')
     parser.add_argument('-cpu', action='store_true', default=False,
                         help='running on CPU (default is on GPU)')
     parser.add_argument('-xla', action='store_true', default=False,
-                        help='enable XLA compiler')
+                        help='enable XLA compiler (experimental)')
     parser.add_argument('-gpu_memory_fraction', type=float, default=0.5,
                         help='determines the fraction of the overall amount of memory '
                              'that each visible GPU should be allocated per worker. '

--- a/server/bert_serving/server/helper.py
+++ b/server/bert_serving/server/helper.py
@@ -6,6 +6,7 @@ import uuid
 import zmq
 from zmq.utils import jsonapi
 
+from . import __version__
 from .graph import PoolingStrategy
 
 __all__ = ['set_logger', 'send_ndarray', 'get_args_parser', 'check_tf_version', 'auto_bind']
@@ -59,8 +60,7 @@ def get_args_parser():
                         help='determines the fraction of the overall amount of memory '
                              'that each visible GPU should be allocated per worker. '
                              'Should be in range [0.0, 1.0]')
-    parser.add_argument('-version', action='store_true', default=False,
-                        help='show version and exit')
+    parser.add_argument('-version', action='version', version='%(prog)s ' + __version__)
     return parser
 
 

--- a/server/bert_serving/server/helper.py
+++ b/server/bert_serving/server/helper.py
@@ -9,14 +9,14 @@ from zmq.utils import jsonapi
 __all__ = ['set_logger', 'send_ndarray', 'get_args_parser', 'check_tf_version', 'auto_bind', 'import_tf']
 
 
-def set_logger(context):
+def set_logger(context, verbose=False):
     logger = logging.getLogger(context)
-    logger.setLevel(logging.INFO)
+    logger.setLevel(logging.DEBUG if verbose else logging.WARNING)
     formatter = logging.Formatter(
         '%(levelname)-.1s:' + context + ':[%(filename).3s:%(funcName).3s:%(lineno)3d]:%(message)s', datefmt=
         '%m-%d %H:%M:%S')
     console_handler = logging.StreamHandler()
-    console_handler.setLevel(logging.INFO)
+    console_handler.setLevel(logging.DEBUG if verbose else logging.WARNING)
     console_handler.setFormatter(formatter)
     logger.handlers = []
     logger.addHandler(console_handler)

--- a/server/bert_serving/server/helper.py
+++ b/server/bert_serving/server/helper.py
@@ -6,8 +6,6 @@ import uuid
 import zmq
 from zmq.utils import jsonapi
 
-from .graph import PoolingStrategy
-
 __all__ = ['set_logger', 'send_ndarray', 'get_args_parser', 'check_tf_version', 'auto_bind', 'import_tf']
 
 
@@ -33,6 +31,8 @@ def send_ndarray(src, dest, X, req_id=b'', flags=0, copy=True, track=False):
 
 def get_args_parser():
     from . import __version__
+    from .graph import PoolingStrategy
+
     parser = argparse.ArgumentParser()
     parser.add_argument('-model_dir', type=str, required=True,
                         help='directory of a pretrained BERT model')

--- a/server/bert_serving/server/helper.py
+++ b/server/bert_serving/server/helper.py
@@ -4,10 +4,10 @@ import os
 import uuid
 
 import zmq
-from bert_serving.server import __version__
 from zmq.utils import jsonapi
 
 from .graph import PoolingStrategy
+from ..server import __version__
 
 __all__ = ['set_logger', 'send_ndarray', 'get_args_parser', 'check_tf_version', 'auto_bind']
 

--- a/server/bert_serving/server/helper.py
+++ b/server/bert_serving/server/helper.py
@@ -11,12 +11,12 @@ __all__ = ['set_logger', 'send_ndarray', 'get_args_parser', 'check_tf_version', 
 
 def set_logger(context, verbose=False):
     logger = logging.getLogger(context)
-    logger.setLevel(logging.DEBUG if verbose else logging.WARNING)
+    logger.setLevel(logging.DEBUG if verbose else logging.INFO)
     formatter = logging.Formatter(
         '%(levelname)-.1s:' + context + ':[%(filename).3s:%(funcName).3s:%(lineno)3d]:%(message)s', datefmt=
         '%m-%d %H:%M:%S')
     console_handler = logging.StreamHandler()
-    console_handler.setLevel(logging.DEBUG if verbose else logging.WARNING)
+    console_handler.setLevel(logging.DEBUG if verbose else logging.INFO)
     console_handler.setFormatter(formatter)
     logger.handlers = []
     logger.addHandler(console_handler)

--- a/server/bert_serving/server/helper.py
+++ b/server/bert_serving/server/helper.py
@@ -6,8 +6,8 @@ import uuid
 import zmq
 from zmq.utils import jsonapi
 
+from . import *
 from .graph import PoolingStrategy
-from ..server import __version__
 
 __all__ = ['set_logger', 'send_ndarray', 'get_args_parser', 'check_tf_version', 'auto_bind']
 

--- a/server/bert_serving/server/helper.py
+++ b/server/bert_serving/server/helper.py
@@ -8,7 +8,7 @@ from zmq.utils import jsonapi
 
 from .graph import PoolingStrategy
 
-__all__ = ['set_logger', 'send_ndarray', 'get_args_parser', 'check_tf_version', 'auto_bind']
+__all__ = ['set_logger', 'send_ndarray', 'get_args_parser', 'check_tf_version', 'auto_bind', 'import_tf']
 
 
 def set_logger(context):
@@ -56,6 +56,8 @@ def get_args_parser():
                         help='running on CPU (default is on GPU)')
     parser.add_argument('-xla', action='store_true', default=False,
                         help='enable XLA compiler (experimental)')
+    parser.add_argument('-verbose', action='store_true', default=False,
+                        help='turn on tensorflow logging for debug')
     parser.add_argument('-gpu_memory_fraction', type=float, default=0.5,
                         help='determines the fraction of the overall amount of memory '
                              'that each visible GPU should be allocated per worker. '
@@ -69,6 +71,14 @@ def check_tf_version():
     tf_ver = tf.__version__.split('.')
     assert int(tf_ver[0]) >= 1 and int(tf_ver[1]) >= 10, 'Tensorflow >=1.10 is required!'
     return tf_ver
+
+
+def import_tf(device_id=-1, verbose=False):
+    os.environ['CUDA_VISIBLE_DEVICES'] = '-1' if device_id < 0 else str(device_id)
+    os.environ['TF_CPP_MIN_LOG_LEVEL'] = '0' if verbose else '3'
+    import tensorflow as tf
+    tf.logging.set_verbosity(tf.logging.DEBUG if verbose else tf.logging.ERROR)
+    return tf
 
 
 def auto_bind(socket):

--- a/server/bert_serving/server/helper.py
+++ b/server/bert_serving/server/helper.py
@@ -6,7 +6,6 @@ import uuid
 import zmq
 from zmq.utils import jsonapi
 
-from . import *
 from .graph import PoolingStrategy
 
 __all__ = ['set_logger', 'send_ndarray', 'get_args_parser', 'check_tf_version', 'auto_bind']
@@ -33,6 +32,7 @@ def send_ndarray(src, dest, X, req_id=b'', flags=0, copy=True, track=False):
 
 
 def get_args_parser():
+    from . import __version__
     parser = argparse.ArgumentParser()
     parser.add_argument('-model_dir', type=str, required=True,
                         help='directory of a pretrained BERT model')

--- a/server/bin/bert-serving-start
+++ b/server/bin/bert-serving-start
@@ -11,7 +11,7 @@ from bert_serving.server.helper import get_args_parser
 def get_print_args():
     args = get_args_parser().parse_args()
     param_str = '\n'.join(['%20s = %s' % (k, v) for k, v in sorted(vars(args).items())])
-    print('usage: %s\n%20s   %s\n%s\n%s\n' % (' '.join(sys.argv), 'ARG', 'VALUE', '_' * 50, param_str))
+    print('usage: %(prog)s %s\n%20s   %s\n%s\n%s\n' % (' '.join(sys.argv), 'ARG', 'VALUE', '_' * 50, param_str))
     return args
 
 

--- a/server/bin/bert-serving-start
+++ b/server/bin/bert-serving-start
@@ -17,9 +17,6 @@ def get_print_args():
 
 if __name__ == '__main__':
     args = get_print_args()
-    if args.version:
-        print('version: %s' % BertServer.__version__)
-    else:
-        server = BertServer(args)
-        server.start()
-        server.join()
+    server = BertServer(args)
+    server.start()
+    server.join()

--- a/server/bin/bert-serving-start
+++ b/server/bin/bert-serving-start
@@ -11,7 +11,7 @@ from bert_serving.server.helper import get_args_parser
 def get_print_args():
     args = get_args_parser().parse_args()
     param_str = '\n'.join(['%20s = %s' % (k, v) for k, v in sorted(vars(args).items())])
-    print('usage: %(prog)s ' + '%s\n%20s   %s\n%s\n%s\n' % (' '.join(sys.argv), 'ARG', 'VALUE', '_' * 50, param_str))
+    print('usage: %s\n%20s   %s\n%s\n%s\n' % (' '.join(sys.argv), 'ARG', 'VALUE', '_' * 50, param_str))
     return args
 
 

--- a/server/bin/bert-serving-start
+++ b/server/bin/bert-serving-start
@@ -11,7 +11,7 @@ from bert_serving.server.helper import get_args_parser
 def get_print_args():
     args = get_args_parser().parse_args()
     param_str = '\n'.join(['%20s = %s' % (k, v) for k, v in sorted(vars(args).items())])
-    print('usage: %(prog)s %s\n%20s   %s\n%s\n%s\n' % (' '.join(sys.argv), 'ARG', 'VALUE', '_' * 50, param_str))
+    print('usage: %(prog)s ' + '%s\n%20s   %s\n%s\n%s\n' % (' '.join(sys.argv), 'ARG', 'VALUE', '_' * 50, param_str))
     return args
 
 


### PR DESCRIPTION
- add timeout to BertClient, fix #134 
- fix `-version` in argparser
- fix device map logic on gpu and cpu
- add `-verbose` for controlling log level
- move msg size to client side for better efficiency
- optimize imports, adding `__all__`