### PR TITLE
Add high priority queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ bert-serving-start -model_dir [-max_seq_len] [-num_worker] [-max_batch_size] [-p
 | `max_seq_len` | int | `25` | maximum length of sequence, longer sequence will be trimmed on the right side. |
 | `num_worker` | int | `1` | number of (GPU/CPU) worker runs BERT model, each works in a separate process. |
 | `max_batch_size` | int | `256` | maximum number of sequences handled by each worker, larger batch will be partitioned into small batches. |
+| `priority_batch_size` | int | `16` | batch smaller than this size will be labeled as high priority, and jumps forward in the job queue to get result faster |
 | `port` | int | `5555` | port for pushing data from client to server |
 | `port_out` | int | `5556`| port for publishing results from server to client |
 | `pooling_strategy` | str | `REDUCE_MEAN` | the pooling strategy for generating encoding vectors, valid values are `NONE`, `REDUCE_MEAN`, `REDUCE_MAX`, `REDUCE_MEAN_MAX`, `CLS_TOKEN`, `FIRST_TOKEN`, `SEP_TOKEN`, `LAST_TOKEN`. Explanation of these strategies [can be found here](#q-what-are-the-available-pooling-strategies). To get encoding for each token in the sequence, please set this to `NONE`.|

--- a/server/bert_serving/server/__init__.py
+++ b/server/bert_serving/server/__init__.py
@@ -384,8 +384,9 @@ class BertWorker(Process):
             while not self.exit_flag.is_set():
                 events = dict(poller.poll())
                 if sock_hprio in events:
-                    yield_job(sock_hprio)
+                    # yield_job(sock_hprio)
                     self.logger.info('a high priority job received')
+                    sock_hprio.recv_multipart()
                 if sock in events:
                     yield_job(sock)
 

--- a/server/bert_serving/server/__init__.py
+++ b/server/bert_serving/server/__init__.py
@@ -86,8 +86,10 @@ class BertServer(threading.Thread):
             """ push to backend based on the msg length """
             if _msg_len <= self.args.priority_batch_size:
                 backend_hprio.send_multipart([_job_id, _json_msg])
+                self.logger.info('a high priority job is pushed')
             else:
                 backend.send_multipart([_job_id, _json_msg])
+                self.logger.info('a job is pushed')
 
         # bind all sockets
         self.logger.info('bind all sockets')

--- a/server/bert_serving/server/__init__.py
+++ b/server/bert_serving/server/__init__.py
@@ -126,6 +126,7 @@ class BertServer(threading.Thread):
                     status_runtime = {'client': client.decode('ascii'),
                                       'num_process': len(self.processes),
                                       'ventilator -> worker': addr_backend,
+                                      'ventilator -> worker (priority)': addr_backend_hprio,
                                       'worker -> sink': addr_sink,
                                       'ventilator <-> sink': addr_front2sink,
                                       'server_current_time': str(datetime.now()),

--- a/server/bert_serving/server/__init__.py
+++ b/server/bert_serving/server/__init__.py
@@ -86,10 +86,8 @@ class BertServer(threading.Thread):
             """ push to backend based on the msg length """
             if _msg_len <= self.args.priority_batch_size:
                 backend_hprio.send_multipart([_job_id, _json_msg])
-                self.logger.info('a high priority job is pushed')
             else:
                 backend.send_multipart([_job_id, _json_msg])
-                self.logger.info('a job is pushed')
 
         # bind all sockets
         self.logger.info('bind all sockets')

--- a/server/bert_serving/server/helper.py
+++ b/server/bert_serving/server/helper.py
@@ -42,6 +42,9 @@ def get_args_parser():
                         help='number of server instances')
     parser.add_argument('-max_batch_size', type=int, default=256,
                         help='maximum number of sequences handled by each worker')
+    parser.add_argument('-priority_batch_size', type=int, default=16,
+                        help='batch smaller than this size will be labeled as high priority,'
+                             'and jumps forward in the job queue')
     parser.add_argument('-port', '-port_in', '-port_data', type=int, default=5555,
                         help='server port for receiving data from client')
     parser.add_argument('-port_out', '-port_result', type=int, default=5556,


### PR DESCRIPTION
a high priority queue/socket is added to ensure small batch requests won't be blocked by super-large batch requests. Previously, if the service is busy handling a super large batch from one client, another client would have to wait until the large batch is fully finished.