### PR TITLE
For Client: update note and set zmq.LINGER zero

### DIFF
--- a/client/bert_serving/client/__init__.py
+++ b/client/bert_serving/client/__init__.py
@@ -41,7 +41,7 @@ class BertClient:
 
         Create a BertClient that connects to a BertServer.
         Note, server must be ready at the moment you are calling this function.
-        If you are not sure whether the server is ready, then please set `check_version=False`
+        If you are not sure whether the server is ready, then please set `check_version=False` and `check_length=False`
 
         You can also use it as a context manager:
 
@@ -75,10 +75,12 @@ class BertClient:
 
         self.context = zmq.Context()
         self.sender = self.context.socket(zmq.PUSH)
+        self.sender.setsockopt(zmq.LINGER, 0)
         self.identity = identity or str(uuid.uuid4()).encode('ascii')
         self.sender.connect('tcp://%s:%d' % (ip, port))
 
         self.receiver = self.context.socket(zmq.SUB)
+        self.receiver.setsockopt(zmq.LINGER, 0)
         self.receiver.setsockopt(zmq.SUBSCRIBE, self.identity)
         self.receiver.connect('tcp://%s:%d' % (ip, port_out))
 

--- a/client/bert_serving/client/__init__.py
+++ b/client/bert_serving/client/__init__.py
@@ -75,12 +75,10 @@ class BertClient:
 
         self.context = zmq.Context()
         self.sender = self.context.socket(zmq.PUSH)
-        self.sender.setsockopt(zmq.LINGER, 0)
         self.identity = identity or str(uuid.uuid4()).encode('ascii')
         self.sender.connect('tcp://%s:%d' % (ip, port))
 
         self.receiver = self.context.socket(zmq.SUB)
-        self.receiver.setsockopt(zmq.LINGER, 0)
         self.receiver.setsockopt(zmq.SUBSCRIBE, self.identity)
         self.receiver.connect('tcp://%s:%d' % (ip, port_out))
 
@@ -122,6 +120,8 @@ class BertClient:
             then this is not necessary.
 
         """
+        self.sender.setsockopt(zmq.LINGER, 0)
+        self.receiver.setsockopt(zmq.LINGER, 0)
         self.sender.close()
         self.receiver.close()
         self.context.term()


### PR DESCRIPTION
* change note: only set `check_version=False` will still send message to server, need set `check_length=False`.
* call BertClient.close() will hang at `self.context.term()`, if server_status is quried from server and timeout. Refer to [StackoverFlow #1](https://stackoverflow.com/questions/46029965/zeromq-blocked-in-a-context-term-call-why-how-to-prevent) and [StackoverFlow #2](https://stackoverflow.com/questions/44273941/python-script-not-terminating-after-timeout-in-zmq-recv), I set zmq.LINGER to zero, and it worked. But I'm not sure is this option will lead to any other problem, so pls help to review, thx.