### PR TITLE
add argument to config tmp file path

### DIFF
--- a/server/bert_serving/server/graph.py
+++ b/server/bert_serving/server/graph.py
@@ -130,7 +130,7 @@ def optimize_graph(args, logger=None):
                 [n.name[:-2] for n in output_tensors],
                 [dtype.as_datatype_enum for dtype in dtypes],
                 False)
-        tmp_file = tempfile.NamedTemporaryFile('w', delete=False).name
+        tmp_file = tempfile.NamedTemporaryFile('w', delete=False, dir=args.graph_tmp_dir).name
         logger.info('write graph to a tmp file: %s' % tmp_file)
         with tf.gfile.GFile(tmp_file, 'wb') as f:
             f.write(tmp_g.SerializeToString())

--- a/server/bert_serving/server/helper.py
+++ b/server/bert_serving/server/helper.py
@@ -69,8 +69,8 @@ def get_args_parser():
                              for a fine-tuned model the name could be different.')
     group1.add_argument('-config_name', type=str, default='bert_config.json',
                         help='filename of the JSON config file for BERT model.')
-    group1.add_argument('-graph_tmp_dir', type=str, default='/tmp',
-                        help='path to graph temp file, default to /tmp')
+    group1.add_argument('-graph_tmp_dir', type=str, default=None,
+                        help='path to graph temp file')
 
     group2 = parser.add_argument_group('BERT Parameters',
                                        'config how BERT model and pooling works')

--- a/server/bert_serving/server/helper.py
+++ b/server/bert_serving/server/helper.py
@@ -69,6 +69,8 @@ def get_args_parser():
                              for a fine-tuned model the name could be different.')
     group1.add_argument('-config_name', type=str, default='bert_config.json',
                         help='filename of the JSON config file for BERT model.')
+    group1.add_argument('-graph_tmp_dir', type=str, default='/tmp',
+                        help='path to graph temp file, default to /tmp')
 
     group2 = parser.add_argument_group('BERT Parameters',
                                        'config how BERT model and pooling works')


### PR DESCRIPTION
serving multiple different bert models on a single machine will generate too many tmp file under /tmp.
I wondering is it possible to add an argument to config where the graph temp file will store