### PR TITLE
Fix #247 Change BertClient Class to Conform with new-style

### DIFF
--- a/client/bert_serving/client/__init__.py
+++ b/client/bert_serving/client/__init__.py
@@ -28,7 +28,7 @@ _Response = namedtuple('_Response', ['id', 'content'])
 Response = namedtuple('Response', ['id', 'embedding', 'tokens'])
 
 
-class BertClient:
+class BertClient(object):
     def __init__(self, ip='localhost', port=5555, port_out=5556,
                  output_fmt='ndarray', show_server_config=False,
                  identity=None, check_version=True, check_length=True,


### PR DESCRIPTION
Inherit from `BertClient` and use super with the conventional syntax.

Example:
```
	class MyBertClient(BertClient):
		def __init__(self, *args, **kwargs):
			super(BertClient, self).__init(*args, **kwargs)
			...
```
