### PR TITLE
Simple dot products aren't sensible scoring functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,8 +296,8 @@ Finally, we are ready to receive new query and perform a simple "fuzzy" search a
 while True:
     query = input('your question: ')
     query_vec = bc.encode([query])[0]
-    # compute simple dot product as score
-    score = np.sum(query_vec * doc_vecs, axis=1)
+    # compute normalized dot product as score
+    score = np.sum(query_vec * doc_vecs, axis=1) / np.linalg.norm(doc_vecs, axis=1)
     topk_idx = np.argsort(score)[::-1][:topk]
     for idx in topk_idx:
         print('> %s\t%s' % (score[idx], questions[idx]))

--- a/client/README.md
+++ b/client/README.md
@@ -295,8 +295,8 @@ Finally, we are ready to receive new query and perform a simple "fuzzy" search a
 while True:
     query = input('your question: ')
     query_vec = bc.encode([query])[0]
-    # compute simple dot product as score
-    score = np.sum(query_vec * doc_vecs, axis=1)
+    # compute normalized dot product as score
+    score = np.sum(query_vec * doc_vecs, axis=1) / np.linalg.norm(doc_vecs, axis=1)
     topk_idx = np.argsort(score)[::-1][:topk]
     for idx in topk_idx:
         print('> %s\t%s' % (score[idx], questions[idx]))

--- a/docs/tutorial/simple-search.rst
+++ b/docs/tutorial/simple-search.rst
@@ -53,8 +53,8 @@ similar questions as follows:
    while True:
        query = input('your question: ')
        query_vec = bc.encode([query])[0]
-       # compute simple dot product as score
-       score = np.sum(query_vec * doc_vecs, axis=1)
+       # compute normalized dot product as score
+       score = np.sum(query_vec * doc_vecs, axis=1) / np.linalg.norm(doc_vecs, axis=1)
        topk_idx = np.argsort(score)[::-1][:topk]
        for idx in topk_idx:
            print('> %s\t%s' % (score[idx], questions[idx]))

--- a/example/example8.py
+++ b/example/example8.py
@@ -28,7 +28,7 @@ with BertClient(port=4000, port_out=4001) as bc:
         query = input(colored('your question: ', 'green'))
         query_vec = bc.encode([query])[0]
         # compute simple dot product as score
-        score = np.sum(query_vec * doc_vecs, axis=1)
+        score = np.sum(query_vec * doc_vecs, axis=1) / np.linalg.norm(doc_vecs, axis=1)
         topk_idx = np.argsort(score)[::-1][:topk]
         print('top %d questions similar to "%s"' % (topk, colored(query, 'green')))
         for idx in topk_idx:

--- a/server/README.md
+++ b/server/README.md
@@ -295,8 +295,8 @@ Finally, we are ready to receive new query and perform a simple "fuzzy" search a
 while True:
     query = input('your question: ')
     query_vec = bc.encode([query])[0]
-    # compute simple dot product as score
-    score = np.sum(query_vec * doc_vecs, axis=1)
+    # compute normalized dot product as score
+    score = np.sum(query_vec * doc_vecs, axis=1) / np.linalg.norm(doc_vecs, axis=1)
     topk_idx = np.argsort(score)[::-1][:topk]
     for idx in topk_idx:
         print('> %s\t%s' % (score[idx], questions[idx]))


### PR DESCRIPTION
The embeddings generated by this library have different norms depending on the input. In my understanding, using a simple dot product as a scoring function for search isn't sensible because the norm of the vector affects the output irrespective of relatedness. 

Cosine similarity is a more suitable metric. But, since the query is fixed across all comparisons, we can safely ignore the query's norm. Thus, a simple solution is to normalize the dot products with the norm of the document.

Qualitatively, the results I get from simple dot products are pretty bad, whereas they're as expected with the normalized version.