### PR TITLE
Add request verification to avoid crash

### DIFF
--- a/server/bert_serving/server/__init__.py
+++ b/server/bert_serving/server/__init__.py
@@ -166,7 +166,9 @@ class BertServer(threading.Thread):
             try:
                 request = frontend.recv_multipart()
                 client, msg, req_id, msg_len = request
-            except ValueError:
+                assert req_id.isdigit()
+                assert msg_len.isdigit()
+            except (ValueError, AssertionError):
                 self.logger.error('received a wrongly-formatted request (expected 4 frames, got %d)' % len(request))
                 self.logger.error('\n'.join('field %d: %s' % (idx, k) for idx, k in enumerate(request)), exc_info=True)
             else:


### PR DESCRIPTION
When server ports are exposed to the public network, there is a risk of malicious requests or scans. The server will crash when the number of frames is satisfied but the last two frames are not integer. So, I added two assert statements to avoid this problem.