### PR TITLE
Added server command line option for cased tokenization

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ bert-serving-benchmark --help
 | `config_name`| str | `bert_config.json` | filename of the JSON config file for BERT model. |
 | `graph_tmp_dir` | str | None | path to graph temp file |  
 | `max_seq_len` | int | `25` | maximum length of sequence, longer sequence will be trimmed on the right side. Set it to NONE for dynamically using the longest sequence in a (mini)batch. |
+| `cased_tokenization` | bool | False | Whether tokenizer should skip the default lowercasing and accent removal. Should be used for e.g. the multilingual cased pretrained BERT model. |
 | `mask_cls_sep` | bool | False | masking the embedding on [CLS] and [SEP] with zero. |
 | `num_worker` | int | `1` | number of (GPU/CPU) worker runs BERT model, each works in a separate process. |
 | `max_batch_size` | int | `256` | maximum number of sequences handled by each worker, larger batch will be partitioned into small batches. |

--- a/server/bert_serving/server/__init__.py
+++ b/server/bert_serving/server/__init__.py
@@ -446,6 +446,7 @@ class BertWorker(Process):
         self.device_id = device_id
         self.logger = set_logger(colored('WORKER-%d' % self.worker_id, 'yellow'), args.verbose)
         self.max_seq_len = args.max_seq_len
+        self.do_lower_case = args.do_lower_case
         self.mask_cls_sep = args.mask_cls_sep
         self.daemon = True
         self.exit_flag = multiprocessing.Event()
@@ -532,10 +533,10 @@ class BertWorker(Process):
         from .bert.tokenization import FullTokenizer
 
         def gen():
-            tokenizer = FullTokenizer(vocab_file=os.path.join(self.model_dir, 'vocab.txt'))
             # Windows does not support logger in MP environment, thus get a new logger
             # inside the process for better compatibility
             logger = set_logger(colored('WORKER-%d' % self.worker_id, 'yellow'), self.verbose)
+            tokenizer = FullTokenizer(vocab_file=os.path.join(self.model_dir, 'vocab.txt'), do_lower_case=self.do_lower_case)
 
             poller = zmq.Poller()
             for sock in socks:

--- a/server/bert_serving/server/helper.py
+++ b/server/bert_serving/server/helper.py
@@ -94,6 +94,9 @@ def get_args_parser():
     group2.add_argument('-max_seq_len', type=check_max_seq_len, default=25,
                         help='maximum length of a sequence, longer sequence will be trimmed on the right side. '
                              'set it to NONE for dynamically using the longest sequence in a (mini)batch.')
+    group2.add_argument('-cased_tokenization', dest='do_lower_case', action='store_false', default=True,
+                        help='Whether tokenizer should skip the default lowercasing and accent removal.'
+                             'Should be used for e.g. the multilingual cased pretrained BERT model.')
     group2.add_argument('-pooling_layer', type=int, nargs='+', default=[-2],
                         help='the encoder layer(s) that receives pooling. \
                         Give a list in order to concatenate several layers into one')


### PR DESCRIPTION
Added server command line option for cased tokenization, as required to keep the casing and accented letters in the pretrained multilingual cased model and other models.

Default behavior is not changed.

Server command line option -cased_tokenization will initialize the tokenizer with do_lower_case=False so that the text doesn't get lowercased and accented letters changed to non-accented versions.

Fixes #328 , fixes #284 