### PR TITLE
Improve statistics performance

### DIFF
--- a/client/bert_serving/client/__init__.py
+++ b/client/bert_serving/client/__init__.py
@@ -105,7 +105,7 @@ class BertClient(object):
         self.token_info_available = False
 
         if not ignore_all_checks and (check_version or show_server_config or check_length or check_token_info):
-            s_status = self.server_status
+            s_status = self.server_config
 
             if check_version and s_status['server_version'] != self.status['client_version']:
                 raise AttributeError('version mismatch! server version is %s but client version is %s!\n'
@@ -220,6 +220,19 @@ class BertClient(object):
 
     @property
     @_timeout
+    def server_config(self):
+        """
+            Get the current configuration of the server connected to this client
+
+        :return: a dictionary contains the current configuration of the server connected to this client
+        :rtype: dict[str, str]
+
+        """
+        req_id = self._send(b'SHOW_CONFIG')
+        return jsonapi.loads(self._recv(req_id).content[1])
+
+    @property
+    @_timeout
     def server_status(self):
         """
             Get the current status of the server connected to this client
@@ -228,7 +241,7 @@ class BertClient(object):
         :rtype: dict[str, str]
 
         """
-        req_id = self._send(b'SHOW_CONFIG')
+        req_id = self._send(b'SHOW_STATUS')
         return jsonapi.loads(self._recv(req_id).content[1])
 
     @_timeout
@@ -472,6 +485,11 @@ class ConcurrentBertClient(BertClient):
 
     @_concurrent
     def encode(self, **kwargs):
+        pass
+
+    @property
+    @_concurrent
+    def server_config(self):
         pass
 
     @property

--- a/server/bert_serving/server/helper.py
+++ b/server/bert_serving/server/helper.py
@@ -5,13 +5,15 @@ import sys
 import time
 import uuid
 import warnings
+from collections import OrderedDict
+
 
 import zmq
 from termcolor import colored
 from zmq.utils import jsonapi
 
 __all__ = ['set_logger', 'send_ndarray', 'get_args_parser',
-           'check_tf_version', 'auto_bind', 'import_tf', 'TimeContext']
+           'check_tf_version', 'auto_bind', 'import_tf', 'TimeContext', 'CappedHistogram']
 
 
 def set_logger(context, verbose=False):
@@ -252,3 +254,83 @@ class TimeContext:
     def __exit__(self, typ, value, traceback):
         self.duration = time.perf_counter() - self.start
         print(colored('    [%3.3f secs]' % self.duration, 'green'), flush=True)
+
+class CappedHistogram:
+    """Space capped dict with aggregate stat tracking.
+
+    Evicts using LRU policy when at capacity; evicted elements are added to aggregate stats.
+    Arguments:
+    capacity -- the capacity limit of the dict
+    """
+    def __init__(self, capacity):
+        self.cache = OrderedDict()
+        self.capacity = capacity
+        self.base_bins = 0
+        self.base_count = 0
+        self.base_min = float('inf')
+        self.min_count = 0
+        self.base_max = 0
+        self.max_count = 0
+
+    def __getitem__(self, key):
+        if key in self.cache:
+            return self.cache[key]
+        return 0
+
+    def __setitem__(self, key, value):
+        if key in self.cache:
+            del self.cache[key]
+        self.cache[key] = value
+        if len(self.cache) > self.capacity:
+            self._evict()
+
+    def total_size(self):
+        return self.base_bins + len(self.cache)
+
+    def __len__(self):
+        return len(self.cache)
+
+    def values(self):
+        return self.cache.values()
+
+    def _evict(self):
+        key,val = self.cache.popitem(False)
+        self.base_bins += 1
+        self.base_count += val
+        if val < self.base_min:
+            self.base_min = val
+            self.min_count = 1
+        elif val == self.base_min:
+            self.min_count += 1
+        if val > self.base_max:
+            self.base_max = val
+            self.max_count = 1
+        elif val == self.base_max:
+            self.max_count += 1
+
+    def get_stat_map(self, name):
+        if len(self.cache) == 0:
+            return {}
+        counts = self.cache.values()
+        avg = (self.base_count + sum(counts)) / (self.base_bins + len(counts))
+        min_, max_ = min(counts), max(counts)
+        num_min, num_max = 0, 0
+        if self.base_min <= min_:
+            min_ = self.base_min
+            num_min += self.min_count
+        if self.base_min >= min_:
+            num_min += sum(v == min_ for v in counts)
+
+        if self.base_max >= max_:
+            max_ = self.base_max
+            num_max += self.max_count
+        if self.base_max <= max_:
+            num_max += sum(v == max_ for v in counts)
+
+        return {
+            'avg_%s' % name: avg,
+            'min_%s' % name: min_,
+            'max_%s' % name: max_,
+            'num_min_%s' % name: num_min,
+            'num_max_%s' % name: num_max,
+        }


### PR DESCRIPTION
I think this will fix issue #400.

By default creating a new client requests server config to check versions, this also builds and sends the server statistics which the client does not use. I've broken it up into `SHOW_CONFIG` and `SHOW_STATUS` so statistic object will only be created/sent when you explicitly request it from client/http endpoint.

I believe the client keyed statistic dicts continue to grow unbounded as long as new clients are created using up memory and slowing down code path. I've replaced them with a dict-like class that takes a set size limit. When the capacity is reached it evicts entries using LRU policy; evicted entries are added to aggregate stats fields for generating info.
These stats may be slightly off if you use more than the capacity of clients simultaneously, but the limit is currently 500 which seems pretty high.

I've changed the calculation for `size_per_request`, the map `{1:100, 2:1}` should have an average size per req of 102/101 not 3/2.