### PR TITLE
Updating bert_serving_start to bert-serving-start

### DIFF
--- a/README.md
+++ b/README.md
@@ -740,12 +740,12 @@ In general, each sentence is translated to a 768-dimensional vector. Depending o
 **A:** Sure! Just use a list of the layer you want to concatenate when calling the server. Example:
 
 ```bash
-bert_serving_start -pooling_layer -4 -3 -2 -1 -model_dir /tmp/english_L-12_H-768_A-12/
+bert-serving-start -pooling_layer -4 -3 -2 -1 -model_dir /tmp/english_L-12_H-768_A-12/
 ```
 
 ##### **Q:** What are the available pooling strategies?
 
-**A:** Here is a table summarizes all pooling strategies I implemented. Choose your favorite one by specifying `bert_serving_start -pooling_strategy`.
+**A:** Here is a table summarizes all pooling strategies I implemented. Choose your favorite one by specifying `bert-serving-start -pooling_strategy`.
 
 |Strategy|Description|
 |---|---|
@@ -793,7 +793,7 @@ No, not at all. Just do `encode` and let the server handles the rest. If the bat
 
 ##### **Q:** How many requests can one service handle concurrently?
 
-**A:** The maximum number of concurrent requests is determined by `num_worker` in `bert_serving_start`. If you a sending more than `num_worker` requests concurrently, the new requests will be temporally stored in a queue until a free worker becomes available.
+**A:** The maximum number of concurrent requests is determined by `num_worker` in `bert-serving-start`. If you a sending more than `num_worker` requests concurrently, the new requests will be temporally stored in a queue until a free worker becomes available.
 
 ##### **Q:** So one request means one sentence?
 

--- a/client/README.md
+++ b/client/README.md
@@ -741,12 +741,12 @@ In general, each sentence is translated to a 768-dimensional vector. Depending o
 **A:** Sure! Just use a list of the layer you want to concatenate when calling the server. Example:
 
 ```bash
-bert_serving_start -pooling_layer -4 -3 -2 -1 -model_dir /tmp/english_L-12_H-768_A-12/
+bert-serving-start -pooling_layer -4 -3 -2 -1 -model_dir /tmp/english_L-12_H-768_A-12/
 ```
 
 ##### **Q:** What are the available pooling strategies?
 
-**A:** Here is a table summarizes all pooling strategies I implemented. Choose your favorite one by specifying `bert_serving_start -pooling_strategy`.
+**A:** Here is a table summarizes all pooling strategies I implemented. Choose your favorite one by specifying `bert-serving-start -pooling_strategy`.
 
 |Strategy|Description|
 |---|---|
@@ -794,7 +794,7 @@ No, not at all. Just do `encode` and let the server handles the rest. If the bat
 
 ##### **Q:** How many requests can one service handle concurrently?
 
-**A:** The maximum number of concurrent requests is determined by `num_worker` in `bert_serving_start`. If you a sending more than `num_worker` requests concurrently, the new requests will be temporally stored in a queue until a free worker becomes available.
+**A:** The maximum number of concurrent requests is determined by `num_worker` in `bert-serving-start`. If you a sending more than `num_worker` requests concurrently, the new requests will be temporally stored in a queue until a free worker becomes available.
 
 ##### **Q:** So one request means one sentence?
 

--- a/docs/section/faq.rst
+++ b/docs/section/faq.rst
@@ -52,14 +52,14 @@ calling the server. Example:
 .. highlight:: bash
 .. code:: bash
 
-   bert_serving_start -pooling_layer -4 -3 -2 -1 -model_dir /tmp/english_L-12_H-768_A-12/
+   bert-serving-start -pooling_layer -4 -3 -2 -1 -model_dir /tmp/english_L-12_H-768_A-12/
 
 What are the available pooling strategies?
 '''''''''''''''''''''''''''''''''''''''''''''''''
 
 Here is a table summarizes all pooling strategies I implemented.
 Choose your favorite one by specifying
-``bert_serving_start -pooling_strategy``.
+``bert-serving-start -pooling_strategy``.
 
 ================================ ========================================================================================================================================================================
 Strategy                         Description
@@ -139,7 +139,7 @@ enough time).
 How many requests can one service handle concurrently?
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 The maximum number of concurrent requests is determined by
-``num_worker`` in ``bert_serving_start``. If you a sending more than
+``num_worker`` in ``bert-serving-start``. If you a sending more than
 ``num_worker`` requests concurrently, the new requests will be
 temporally stored in a queue until a free worker becomes available.
 

--- a/server/README.md
+++ b/server/README.md
@@ -741,12 +741,12 @@ In general, each sentence is translated to a 768-dimensional vector. Depending o
 **A:** Sure! Just use a list of the layer you want to concatenate when calling the server. Example:
 
 ```bash
-bert_serving_start -pooling_layer -4 -3 -2 -1 -model_dir /tmp/english_L-12_H-768_A-12/
+bert-serving-start -pooling_layer -4 -3 -2 -1 -model_dir /tmp/english_L-12_H-768_A-12/
 ```
 
 ##### **Q:** What are the available pooling strategies?
 
-**A:** Here is a table summarizes all pooling strategies I implemented. Choose your favorite one by specifying `bert_serving_start -pooling_strategy`.
+**A:** Here is a table summarizes all pooling strategies I implemented. Choose your favorite one by specifying `bert-serving-start -pooling_strategy`.
 
 |Strategy|Description|
 |---|---|
@@ -794,7 +794,7 @@ No, not at all. Just do `encode` and let the server handles the rest. If the bat
 
 ##### **Q:** How many requests can one service handle concurrently?
 
-**A:** The maximum number of concurrent requests is determined by `num_worker` in `bert_serving_start`. If you a sending more than `num_worker` requests concurrently, the new requests will be temporally stored in a queue until a free worker becomes available.
+**A:** The maximum number of concurrent requests is determined by `num_worker` in `bert-serving-start`. If you a sending more than `num_worker` requests concurrently, the new requests will be temporally stored in a queue until a free worker becomes available.
 
 ##### **Q:** So one request means one sentence?
 


### PR DESCRIPTION
This is a quick pull request to change instances of `bert_serving_start` to `bert-serving-start`, which seems to be the correct entrypoint for the module!

```python
        'console_scripts': ['bert-serving-start=bert_serving.server.cli:main',
```

I would bet it used to be the other one? And then someone decided that dashes > underscore :)

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>