### PR TITLE
Add a config which can let bert not add CLS and SEP automatically

### DIFF
--- a/server/bert_serving/server/__init__.py
+++ b/server/bert_serving/server/__init__.py
@@ -474,6 +474,7 @@ class BertWorker(Process):
         self.bert_config = graph_config
         self.use_fp16 = args.fp16
         self.show_tokens_to_client = args.show_tokens_to_client
+        self.no_special_token = args.no_special_token
         self.is_ready = multiprocessing.Event()
 
     def close(self):
@@ -570,7 +571,7 @@ class BertWorker(Process):
                         tmp_f = list(convert_lst_to_features(msg, self.max_seq_len,
                                                              self.bert_config.max_position_embeddings,
                                                              tokenizer, logger,
-                                                             is_tokenized, self.mask_cls_sep))
+                                                             is_tokenized, self.mask_cls_sep, self.no_special_token))
                         if self.show_tokens_to_client:
                             sink.send_multipart([client_id, jsonapi.dumps([f.tokens for f in tmp_f]),
                                                  b'', ServerCmd.data_token])

--- a/server/bert_serving/server/helper.py
+++ b/server/bert_serving/server/helper.py
@@ -109,6 +109,10 @@ def get_args_parser():
                         help='masking the embedding on [CLS] and [SEP] with zero. \
                         When pooling_strategy is in {CLS_TOKEN, FIRST_TOKEN, SEP_TOKEN, LAST_TOKEN} \
                         then the embedding is preserved, otherwise the embedding is masked to zero before pooling')
+    group2.add_argument('-no_special_token', action='store_true', default=False,
+                        help='add [CLS] and [SEP] in every sequence, \
+                        put sequence to the model without [CLS] and [SEP] when True and \
+                        is_tokenized=True in Client')
     group2.add_argument('-show_tokens_to_client', action='store_true', default=False,
                         help='sending tokenization results to client')
 


### PR DESCRIPTION
I want to add this because I need a long sentence representation. My way is split sentence and through bert and combine it. It works fine in experiments. 

Maybe the name of config is not good, modify it if you want