### PR TITLE
added pooling strategy for CLS_POOLED

### DIFF
--- a/server/bert_serving/server/graph.py
+++ b/server/bert_serving/server/graph.py
@@ -21,6 +21,7 @@ class PoolingStrategy(Enum):
     LAST_TOKEN = 5  # corresponds to [SEP] for single sequences
     CLS_TOKEN = 4  # corresponds to the first token for single seq.
     SEP_TOKEN = 5  # corresponds to the last token for single seq.
+    CLS_POOLED = 6 #pooled [CLS] token for fine-tuned classification
 
     def __str__(self):
         return self.name
@@ -107,6 +108,8 @@ def optimize_graph(args, logger=None):
                 elif args.pooling_strategy == PoolingStrategy.FIRST_TOKEN or \
                         args.pooling_strategy == PoolingStrategy.CLS_TOKEN:
                     pooled = tf.squeeze(encoder_layer[:, 0:1, :], axis=1)
+                elif args.pooling_strategy == PoolingStrategy.CLS_POOLED:
+                    pooled = model.pooled_output
                 elif args.pooling_strategy == PoolingStrategy.LAST_TOKEN or \
                         args.pooling_strategy == PoolingStrategy.SEP_TOKEN:
                     seq_len = tf.cast(tf.reduce_sum(input_mask, axis=1), tf.int32)


### PR DESCRIPTION
in the original Google BERT paper, after fine-tuning is done on a classification task, the CLS token is pooled with a single tanh layer before it is sent to the linear classifier head. this PR adds an additional pooling strategy that uses the CLS pooling already in the BERT graph.  @hanxiao 