### PR TITLE
OpenAPI contract and SwaggerUI support for bert-as-service

### DIFF
--- a/server/bert_serving/server/bertApi.openapi.yaml
+++ b/server/bert_serving/server/bertApi.openapi.yaml
@@ -1,0 +1,247 @@
+openapi: "3.0.2"
+info:
+  version: 1.0.0
+  title: Bert as a Service API
+  description: API to encode sentence or tokens to vectors
+  termsOfService: http://swagger.io/terms/
+  contact:
+    name: Filip Bednárik
+    email: info@ardevop.sk
+    url: https://ardevop.sk
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+servers:
+  - url: http://localhost:8125/
+paths:
+  /encode:
+    post:
+      description: |
+        Encode a list of strings to a list of vectors
+      operationId: app.encode_query
+      requestBody:
+        description: EncodeRequest to apply
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EncodeRequest'
+      responses:
+        '200':
+          description: Encode response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EncodeResponse'
+        default:
+          description: unexpected error
+  /status/server:
+    get:
+      description: Returns server status
+      operationId: get_server_status
+      responses:
+        '200':
+          description: Server status response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServerStatusResponse'
+        default:
+          description: unexpected error
+  /status/client:
+    get:
+      description: Returns client status
+      operationId: get_client_status
+      responses:
+        '200':
+          description: Client status response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClientStatusResponse'
+        default:
+          description: unexpected error
+components:
+  schemas:
+    EncodeRequest:
+      type: object
+      required: 
+        - id
+        - texts
+        - is_tokenized
+      properties:
+        id:
+          type: integer
+        texts:
+          type: array
+          items:
+            type: string
+        is_tokenized:
+          type: boolean
+          default: false
+    EncodeResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+        results:
+          type: array
+          items:
+            type: array
+            items:
+              type: number
+        status:
+          type: integer
+    ServerStatusResponse:
+      type: object
+      properties:
+        ckpt_name:
+          type: string
+        client:
+          type: string
+        config_name:
+          type: string
+        cors:
+          type: string
+        cpu:
+          type: boolean
+        device_map:
+          type: array
+          items:
+            type: integer
+        do_lower_case:
+          type: boolean
+        fixed_embed_length:
+          type: boolean
+        fp16:
+          type: boolean
+        gpu_memory_fraction:
+          type: number
+        graph_tmp_dir:
+          type: string
+        http_max_connect:
+          type: integer
+        http_port:
+          type: integer
+        mask_cls_sep:
+          type: boolean
+        max_batch_size:
+          type: integer
+        max_seq_len:
+          type: integer
+        model_dir:
+          type: string
+        no_position_embeddings:
+          type: boolean
+        no_special_token:
+          type: boolean
+        num_concurrent_socket:
+          type: integer
+        num_process:
+          type: integer
+        num_worker:
+          type: integer
+        pooling_layer:
+          type: array
+          items:
+            type: integer
+        pooling_strategy:
+          type: integer
+        port:
+          type: integer
+        port_out:
+          type: integer
+        prefetch_size:
+          type: integer
+        priority_batch_size:
+          type: integer
+        python_version:
+          type: string
+        pyzmq_version:
+          type: string
+        server_current_time:
+          type: string
+        server_start_time:
+          type: string
+        server_version:
+          type: string
+        show_tokens_to_client:
+          type: boolean
+        statistic:
+          $ref: '#/components/schemas/Statistic'
+        status:
+          type: integer
+        tensorflow_version:
+          type: array
+          items:
+            type: string
+        tuned_model_dir:
+          type: string
+        "ventilator -> worker":
+          type: array
+          items:
+            type: string
+        "ventilator <-> sink":
+          type: string
+        verbose:
+          type: boolean
+        "worker -> sink":
+          type: string
+        xla:
+          type: boolean
+        zmq_version:
+          type: string
+    Statistic:
+      type: object
+      properties:
+        avg_request_per_client:
+          type: integer
+        max_request_per_client:
+          type: integer
+        min_request_per_client:
+          type: integer
+        num_active_client:
+          type: integer
+        num_data_request:
+          type: integer
+        num_max_request_per_client:
+          type: integer
+        num_min_request_per_client:
+          type: integer
+        num_sys_request:
+          type: integer
+        num_total_client:
+          type: integer
+        num_total_request:
+          type: integer
+        num_total_seq:
+          type: integer
+    ClientStatusResponse:
+      type: object
+      properties:
+        client_version:
+          type: string
+        identity:
+          type: array
+          items:
+            type: integer
+        num_pending_request:
+          type: integer
+        num_request:
+          type: integer
+        output_fmt:
+          type: string
+        pending_request:
+          type: array
+          items:
+            type: integer
+        port:
+          type: integer
+        port_out:
+          type: integer
+        server_ip:
+          type: string
+        status:
+          type: integer
+        timeout:
+          type: integer

--- a/server/bert_serving/server/http.py
+++ b/server/bert_serving/server/http.py
@@ -18,6 +18,7 @@ class BertHTTPProxy(Process):
             from flask_cors import CORS
             from flask_json import FlaskJSON, as_json, JsonError
             from bert_serving.client import ConcurrentBertClient
+            from flasgger import Swagger
         except ImportError:
             raise ImportError('BertClient or Flask or its dependencies are not fully installed, '
                               'they are required for serving HTTP requests.'
@@ -28,6 +29,13 @@ class BertHTTPProxy(Process):
                                   port=self.args.port, port_out=self.args.port_out,
                                   output_fmt='list', ignore_all_checks=True)
         app = Flask(__name__)
+        app.config['SWAGGER'] = {
+          'title': 'Colors API',
+          'uiversion': 3,
+          'openapi': '3.0.2'
+        }
+        swag = Swagger(app, template_file='bertApi.openapi.yaml')
+
         logger = set_logger(colored('PROXY', 'red'))
 
         @app.route('/status/server', methods=['GET'])

--- a/server/setup.py
+++ b/server/setup.py
@@ -13,7 +13,7 @@ setup(
     version=__version__,
     description='Mapping a variable-length sentence to a fixed-length vector using BERT model (Server)',
     url='https://github.com/hanxiao/bert-as-service',
-    long_description=open('README.md', 'r').read(),
+    long_description=open('README.md', 'r', encoding="utf8").read(),
     long_description_content_type='text/markdown',
     author='Han Xiao',
     author_email='artex.xh@gmail.com',


### PR DESCRIPTION
Hello,
I have integrated [SwaggerUI](https://swagger.io/tools/swagger-ui/) into Flask http server and defined a [OpenAPI contract definition](https://swagger.io/docs/specification/about/) to support testing the API from browser and [generating clients for various languages.](https://github.com/OpenAPITools/openapi-generator) 

Open issues:
- Readme should be updated.
- Maybe it could be optional?
- Tokenization result is not present (it wasn't in http implementation either so it is not in contract)
- I have entered my info into contract, feel free to change it to something more appropriate

I am opened to feedback.
Thank you,
Filip