### PR TITLE
Improvements to Docker deployment

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,7 @@
 FROM tensorflow/tensorflow:1.12.0-gpu-py3
-RUN pip install bert-serving-server
-COPY ./ /app
+RUN pip install bert-serving-server[http]
 COPY ./docker/entrypoint.sh /app
 WORKDIR /app
 ENTRYPOINT ["/app/entrypoint.sh"]
 CMD []
-
+HEALTHCHECK --timeout=5s CMD curl -f http://localhost:8125/status/server || exit 1

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-bert-serving-start -num_worker=$1 -model_dir /model
+bert-serving-start -http_port 8125 -num_worker=$1 -model_dir /model


### PR DESCRIPTION
This PR makes three changes to the Docker deployment:

- The service is installed with HTTP support and started with the HTTP endpoint running. Given the image comes out several gigabytes in size, the extra image size of doing this is negligible and if the HTTP endpoint is not needed then the user can simply choose not to expose the port (which needs `-p 8125:8125` on the docker command line)
- Since all dependencies and code are installed with the `pip` command, the copying of the full source (and documentation!) into the Docker image has been removed. This both makes a slightly smaller image and improves both build speed and build cachability.
- A `HEALTHCHECK` setting has been added to the `Dockerfile` so that Docker will report the status of the service in `docker ps`.