### PR TITLE
Fixed a small issue in folder name

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM tensorflow/tensorflow:1.12.0-gpu-py3
 RUN pip install bert-serving-server[http]
-COPY ./docker/entrypoint.sh /app
+COPY ./docker/entrypoint.sh /app/
 WORKDIR /app
 ENTRYPOINT ["/app/entrypoint.sh"]
 CMD []


### PR DESCRIPTION
Line 3 without `/` at the end, copied `entrypoint.sh` as `/app`, instead of putting that file inside the `/app` folder
adding `/` at the end, solves the problem.