### PR TITLE
Refine log format.

### DIFF
--- a/server/bert_serving/server/helper.py
+++ b/server/bert_serving/server/helper.py
@@ -23,8 +23,7 @@ def set_logger(context, verbose=False):
     logger = logging.getLogger(context)
     logger.setLevel(logging.DEBUG if verbose else logging.INFO)
     formatter = logging.Formatter(
-        '%(levelname)-.1s:' + context + ':[%(filename).3s:%(funcName).3s:%(lineno)3d]:%(message)s', datefmt=
-        '%m-%d %H:%M:%S')
+        '[%(asctime)s] %(levelname)s ' + context + ' [%(filename)s:%(funcName)s:%(lineno)3d] %(message)s')
     console_handler = logging.StreamHandler()
     console_handler.setLevel(logging.DEBUG if verbose else logging.INFO)
     console_handler.setFormatter(formatter)


### PR DESCRIPTION
The original log format I think is somehow obscure, so I make some refines.

The new log format looks like this:

[2020-06-10 10:44:21,380] INFO WORKER-0 [__init__.py:gen:560] ready and listening!
[2020-06-10 10:44:21,380] INFO WORKER-1 [__init__.py:gen:560] ready and listening!
[2020-06-10 10:44:21,385] INFO VENTILATOR [__init__.py:_run:164] all set, ready to serve request!
[2020-06-10 10:45:06,047] INFO VENTILATOR [__init__.py:_run:180] new config request	req id: 1	client: b'1e7f60ea-d5f6-4759-bd75-365aa52a50a5'
[2020-06-10 10:45:06,151] INFO SINK [__init__.py:_run:348] send config	client b'1e7f60ea-d5f6-4759-bd75-365aa52a50a5'
[2020-06-10 10:45:06,154] INFO VENTILATOR [__init__.py:_run:196] new encode request	req id: 2	size: 2	client: b'1e7f60ea-d5f6-4759-bd75-365aa52a50a5'
[2020-06-10 10:45:06,155] INFO SINK [__init__.py:_run:342] job register	size: 2	job id: b'1e7f60ea-d5f6-4759-bd75-365aa52a50a5#2'