### PR TITLE
Updated readme for TF version

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ pip install bert-serving-server  # server
 pip install bert-serving-client  # client, independent of `bert-serving-server`
 ```
 
-Note that the server MUST be running on **Python >= 3.5** with **Tensorflow >= 1.10** (*one-point-ten*). Again, the server does not support Python 2!
+Note that the server MUST be running on **Python >= 3.5** with **Tensorflow >= 1.10, Tensorflow < 2.0** (*one-point-ten*). Again, the server does not support Python 2!
 
 :point_up: The client can be running on both Python 2 and 3 [for the following consideration](#q-can-i-run-it-in-python-2).
 


### PR DESCRIPTION
Need to specify that TF version less than 2.0 works, TF version greater than 1.10 only will not suffice